### PR TITLE
Update XQuartz package source

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,6 @@
 class xquartz {
   package { 'XQuartz':
     provider => 'pkgdmg',
-    source   => 'http://static.macosforge.org/xquartz/downloads/SL/XQuartz-2.7.2.dmg'
+    source   => 'http://xquartz.macosforge.org/downloads/SL/XQuartz-2.7.2.dmg',
   }
 }


### PR DESCRIPTION
With the module as it currently stands, I was getting failures trying
to source the DMG from its current location. This commit uses a URL
from the xquartz.macosforge.org website to source the package.
