### PR TITLE
Update to XQuartz 2.7.5

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,6 @@
 class xquartz {
   package { 'XQuartz':
     provider => 'pkgdmg',
-    source   => 'http://xquartz.macosforge.org/downloads/SL/XQuartz-2.7.4.dmg',
+    source   => 'http://xquartz.macosforge.org/downloads/SL/XQuartz-2.7.5.dmg',
   }
 }

--- a/spec/classes/xquartz_spec.rb
+++ b/spec/classes/xquartz_spec.rb
@@ -4,7 +4,7 @@ describe 'xquartz' do
   it do
     should contain_package('XQuartz').with({
       :provider => 'pkgdmg',
-      :source   => 'http://xquartz.macosforge.org/downloads/SL/XQuartz-2.7.4.dmg'
+      :source   => 'http://xquartz.macosforge.org/downloads/SL/XQuartz-2.7.5.dmg'
     })
   end
 end


### PR DESCRIPTION
Mavericks requires version 2.7.5

![screen shot 2013-11-11 at 10 54 25](https://f.cloud.github.com/assets/678372/1512123/691ce372-4ac2-11e3-9fe8-597f48c0b905.jpg)

Closes #6 
