### PR TITLE
Update to XQuartz 2.7.6

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,6 @@
 class xquartz {
   package { 'XQuartz':
     provider => 'pkgdmg',
-    source   => 'http://xquartz.macosforge.org/downloads/SL/XQuartz-2.7.5.dmg',
+    source   => 'http://xquartz.macosforge.org/downloads/SL/XQuartz-2.7.6.dmg',
   }
 }

--- a/spec/classes/xquartz_spec.rb
+++ b/spec/classes/xquartz_spec.rb
@@ -4,7 +4,7 @@ describe 'xquartz' do
   it do
     should contain_package('XQuartz').with({
       :provider => 'pkgdmg',
-      :source   => 'http://xquartz.macosforge.org/downloads/SL/XQuartz-2.7.5.dmg'
+      :source   => 'http://xquartz.macosforge.org/downloads/SL/XQuartz-2.7.6.dmg'
     })
   end
 end


### PR DESCRIPTION
## Summary

Apple [released XQuartz 2.7.6 on 2014.05.17](http://xquartz.macosforge.org/trac/wiki/X112.7.6). In addition to updating several library dependencies XQuartz 2.7.6 addresses several CVE's the worst of which may allow remote attackers to cause a denial of service (crash) and possibly execute arbitrary code.
## CVE's
- [CVE-2014-2240](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-2240)
- [CVE-2013-6462](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-6462)
- [CVE-2014-0209](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-0209)
- [CVE-2014-0210](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-0210)
- [CVE-2014-0211](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-0211)
